### PR TITLE
Issue #7 - Fix

### DIFF
--- a/apps/www/app/docs/[[...slug]]/page.tsx
+++ b/apps/www/app/docs/[[...slug]]/page.tsx
@@ -37,7 +37,7 @@ export default async function DocPage({ params }: DocPageProps) {
   const toc = await getTableOfContents(doc.body.raw)
 
   return (
-    <main className="md:w-[calc(theme(screens.md)-220px)] lg:w-[calc(theme(screens.lg)-theme(spacing.16)-240px)] lg:gap-10 lg:py-10 xl:grid xl:grid-cols-[1fr_300px]">
+    <main className="relative py-6 md:w-[calc(theme(screens.md)-220px)] lg:w-[calc(theme(screens.lg)-theme(spacing.16)-240px)] lg:gap-10 lg:py-10 xl:grid xl:grid-cols-[1fr_300px]">
       <div className="mx-auto w-full min-w-0">
         <DocsPageHeader heading={doc.title} text={doc.description}>
           {doc.radix ? (

--- a/apps/www/app/docs/[[...slug]]/page.tsx
+++ b/apps/www/app/docs/[[...slug]]/page.tsx
@@ -37,7 +37,7 @@ export default async function DocPage({ params }: DocPageProps) {
   const toc = await getTableOfContents(doc.body.raw)
 
   return (
-    <main className="relative py-6 lg:gap-10 lg:py-10 xl:grid xl:grid-cols-[1fr_300px]">
+    <main className="md:w-[calc(theme(screens.md)-220px)] lg:w-[calc(theme(screens.lg)-theme(spacing.16)-240px)] lg:gap-10 lg:py-10 xl:grid xl:grid-cols-[1fr_300px]">
       <div className="mx-auto w-full min-w-0">
         <DocsPageHeader heading={doc.title} text={doc.description}>
           {doc.radix ? (

--- a/apps/www/components/main-nav.tsx
+++ b/apps/www/components/main-nav.tsx
@@ -31,14 +31,14 @@ export function MainNav({ items, children }: MainNavProps) {
 
   return (
     <div className="flex gap-6 md:gap-10">
-      <Link href="/" className="hidden items-center space-x-2 lg:flex">
+      <Link href="/" className="hidden items-center space-x-2 md:flex">
         <Icons.logo className="h-6 w-6" />
         <span className="hidden font-bold sm:inline-block">
           {siteConfig.name}
         </span>
       </Link>
       {items?.length ? (
-        <nav className="hidden gap-6 lg:flex">
+        <nav className="hidden gap-6 md:flex">
           {items?.map(
             (item, index) =>
               item.href && (
@@ -61,7 +61,7 @@ export function MainNav({ items, children }: MainNavProps) {
         <DropdownMenuTrigger asChild>
           <Button
             variant="ghost"
-            className="-ml-4 text-base hover:bg-transparent focus:ring-0 lg:hidden"
+            className="-ml-4 text-base hover:bg-transparent focus:ring-0 md:hidden"
           >
             <Icons.logo className="mr-2 h-4 w-4" />{" "}
             <span className="font-bold">Menu</span>

--- a/apps/www/components/main-nav.tsx
+++ b/apps/www/components/main-nav.tsx
@@ -31,14 +31,14 @@ export function MainNav({ items, children }: MainNavProps) {
 
   return (
     <div className="flex gap-6 md:gap-10">
-      <Link href="/" className="hidden items-center space-x-2 md:flex">
+      <Link href="/" className="hidden items-center space-x-2 lg:flex">
         <Icons.logo className="h-6 w-6" />
         <span className="hidden font-bold sm:inline-block">
           {siteConfig.name}
         </span>
       </Link>
       {items?.length ? (
-        <nav className="hidden gap-6 md:flex">
+        <nav className="hidden gap-6 lg:flex">
           {items?.map(
             (item, index) =>
               item.href && (
@@ -61,7 +61,7 @@ export function MainNav({ items, children }: MainNavProps) {
         <DropdownMenuTrigger asChild>
           <Button
             variant="ghost"
-            className="-ml-4 text-base hover:bg-transparent focus:ring-0 md:hidden"
+            className="-ml-4 text-base hover:bg-transparent focus:ring-0 lg:hidden"
           >
             <Icons.logo className="mr-2 h-4 w-4" />{" "}
             <span className="font-bold">Menu</span>


### PR DESCRIPTION
This pull request fixes an issue with the component demo going very far off the screen on the X axis at a resolution of 1024. The issue happened at the `md` and `lg` breakpoints, with the addition of the `<aside>` element seemingly breaking the `width: 100%` calculations. Solved the issue by calculating the width based on screen size for the `md` and `lg` breakpoints.

![image](https://user-images.githubusercontent.com/12982889/214609832-375ded56-ef05-4aa0-aaaa-f8015ed34b3f.png)
