### PR TITLE
fix: Multiple typos in primitives (`Primivite` -> `Primitive`)

### DIFF
--- a/apps/www/components/ui/avatar.tsx
+++ b/apps/www/components/ui/avatar.tsx
@@ -1,15 +1,15 @@
 "use client"
 
 import * as React from "react"
-import * as AvatarPrimivite from "@radix-ui/react-avatar"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
 
 import { cn } from "@/lib/utils"
 
 const Avatar = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimivite.Root>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimivite.Root>
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
 >(({ className, ...props }, ref) => (
-  <AvatarPrimivite.Root
+  <AvatarPrimitive.Root
     ref={ref}
     className={cn(
       "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
@@ -18,25 +18,25 @@ const Avatar = React.forwardRef<
     {...props}
   />
 ))
-Avatar.displayName = AvatarPrimivite.Root.displayName
+Avatar.displayName = AvatarPrimitive.Root.displayName
 
 const AvatarImage = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimivite.Image>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimivite.Image>
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
 >(({ className, ...props }, ref) => (
-  <AvatarPrimivite.Image
+  <AvatarPrimitive.Image
     ref={ref}
     className={cn("aspect-square h-full w-full", className)}
     {...props}
   />
 ))
-AvatarImage.displayName = AvatarPrimivite.Image.displayName
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
 
 const AvatarFallback = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimivite.Fallback>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimivite.Fallback>
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
 >(({ className, ...props }, ref) => (
-  <AvatarPrimivite.Fallback
+  <AvatarPrimitive.Fallback
     ref={ref}
     className={cn(
       "flex h-full w-full items-center justify-center rounded-full bg-slate-100 dark:bg-slate-700",
@@ -45,6 +45,6 @@ const AvatarFallback = React.forwardRef<
     {...props}
   />
 ))
-AvatarFallback.displayName = AvatarPrimivite.Fallback.displayName
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
 
 export { Avatar, AvatarImage, AvatarFallback }

--- a/apps/www/components/ui/tabs.tsx
+++ b/apps/www/components/ui/tabs.tsx
@@ -1,17 +1,17 @@
 "use client"
 
 import * as React from "react"
-import * as TabsPrimivite from "@radix-ui/react-tabs"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
 
 import { cn } from "@/lib/utils"
 
-const Tabs = TabsPrimivite.Root
+const Tabs = TabsPrimitive.Root
 
 const TabsList = React.forwardRef<
-  React.ElementRef<typeof TabsPrimivite.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimivite.List>
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
 >(({ className, ...props }, ref) => (
-  <TabsPrimivite.List
+  <TabsPrimitive.List
     ref={ref}
     className={cn(
       "inline-flex items-center justify-center rounded-md bg-slate-100 p-1 dark:bg-slate-800",
@@ -20,13 +20,13 @@ const TabsList = React.forwardRef<
     {...props}
   />
 ))
-TabsList.displayName = TabsPrimivite.List.displayName
+TabsList.displayName = TabsPrimitive.List.displayName
 
 const TabsTrigger = React.forwardRef<
-  React.ElementRef<typeof TabsPrimivite.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimivite.Trigger>
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
 >(({ className, ...props }, ref) => (
-  <TabsPrimivite.Trigger
+  <TabsPrimitive.Trigger
     className={cn(
       "inline-flex min-w-[100px] items-center justify-center rounded-[0.185rem] px-3 py-1.5  text-sm font-medium text-slate-700 transition-all  disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-white data-[state=active]:text-slate-900 data-[state=active]:shadow-sm dark:text-slate-200 dark:data-[state=active]:bg-slate-900",
       className
@@ -35,13 +35,13 @@ const TabsTrigger = React.forwardRef<
     ref={ref}
   />
 ))
-TabsTrigger.displayName = TabsPrimivite.Trigger.displayName
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
 
 const TabsContent = React.forwardRef<
-  React.ElementRef<typeof TabsPrimivite.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimivite.Content>
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
 >(({ className, ...props }, ref) => (
-  <TabsPrimivite.Content
+  <TabsPrimitive.Content
     className={cn(
       "mt-2 rounded-md border border-slate-200 p-6 dark:border-slate-700",
       className
@@ -50,6 +50,6 @@ const TabsContent = React.forwardRef<
     ref={ref}
   />
 ))
-TabsContent.displayName = TabsPrimivite.Content.displayName
+TabsContent.displayName = TabsPrimitive.Content.displayName
 
 export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/templates/next-template/components/ui/avatar.tsx
+++ b/templates/next-template/components/ui/avatar.tsx
@@ -1,15 +1,15 @@
 "use client"
 
 import * as React from "react"
-import * as AvatarPrimivite from "@radix-ui/react-avatar"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
 
 import { cn } from "@/lib/utils"
 
 const Avatar = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimivite.Root>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimivite.Root>
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
 >(({ className, ...props }, ref) => (
-  <AvatarPrimivite.Root
+  <AvatarPrimitive.Root
     ref={ref}
     className={cn(
       "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
@@ -18,25 +18,25 @@ const Avatar = React.forwardRef<
     {...props}
   />
 ))
-Avatar.displayName = AvatarPrimivite.Root.displayName
+Avatar.displayName = AvatarPrimitive.Root.displayName
 
 const AvatarImage = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimivite.Image>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimivite.Image>
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
 >(({ className, ...props }, ref) => (
-  <AvatarPrimivite.Image
+  <AvatarPrimitive.Image
     ref={ref}
     className={cn("aspect-square h-full w-full", className)}
     {...props}
   />
 ))
-AvatarImage.displayName = AvatarPrimivite.Image.displayName
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
 
 const AvatarFallback = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimivite.Fallback>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimivite.Fallback>
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
 >(({ className, ...props }, ref) => (
-  <AvatarPrimivite.Fallback
+  <AvatarPrimitive.Fallback
     ref={ref}
     className={cn(
       "flex h-full w-full items-center justify-center rounded-full bg-slate-100 dark:bg-slate-700",
@@ -45,6 +45,6 @@ const AvatarFallback = React.forwardRef<
     {...props}
   />
 ))
-AvatarFallback.displayName = AvatarPrimivite.Fallback.displayName
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
 
 export { Avatar, AvatarImage, AvatarFallback }

--- a/templates/next-template/components/ui/tabs.tsx
+++ b/templates/next-template/components/ui/tabs.tsx
@@ -1,17 +1,17 @@
 "use client"
 
 import * as React from "react"
-import * as TabsPrimivite from "@radix-ui/react-tabs"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
 
 import { cn } from "@/lib/utils"
 
-const Tabs = TabsPrimivite.Root
+const Tabs = TabsPrimitive.Root
 
 const TabsList = React.forwardRef<
-  React.ElementRef<typeof TabsPrimivite.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimivite.List>
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
 >(({ className, ...props }, ref) => (
-  <TabsPrimivite.List
+  <TabsPrimitive.List
     ref={ref}
     className={cn(
       "inline-flex items-center justify-center rounded-md bg-slate-100 p-1 dark:bg-slate-800",
@@ -20,13 +20,13 @@ const TabsList = React.forwardRef<
     {...props}
   />
 ))
-TabsList.displayName = TabsPrimivite.List.displayName
+TabsList.displayName = TabsPrimitive.List.displayName
 
 const TabsTrigger = React.forwardRef<
-  React.ElementRef<typeof TabsPrimivite.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimivite.Trigger>
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
 >(({ className, ...props }, ref) => (
-  <TabsPrimivite.Trigger
+  <TabsPrimitive.Trigger
     className={cn(
       "inline-flex min-w-[100px] items-center justify-center rounded-[0.185rem] px-3 py-1.5  text-sm font-medium text-slate-700 transition-all  disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-white data-[state=active]:text-slate-900 data-[state=active]:shadow-sm dark:text-slate-200 dark:data-[state=active]:bg-slate-900",
       className
@@ -35,13 +35,13 @@ const TabsTrigger = React.forwardRef<
     ref={ref}
   />
 ))
-TabsTrigger.displayName = TabsPrimivite.Trigger.displayName
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
 
 const TabsContent = React.forwardRef<
-  React.ElementRef<typeof TabsPrimivite.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimivite.Content>
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
 >(({ className, ...props }, ref) => (
-  <TabsPrimivite.Content
+  <TabsPrimitive.Content
     className={cn(
       "mt-2 rounded-md border border-slate-200 p-6 dark:border-slate-700",
       className
@@ -50,6 +50,6 @@ const TabsContent = React.forwardRef<
     ref={ref}
   />
 ))
-TabsContent.displayName = TabsPrimivite.Content.displayName
+TabsContent.displayName = TabsPrimitive.Content.displayName
 
 export { Tabs, TabsList, TabsTrigger, TabsContent }


### PR DESCRIPTION
This PR fixes some typos for the usage of the word "primitive".