### PR TITLE
fix: add `display: 'swap'` for fonts

### DIFF
--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -11,6 +11,7 @@ import { ThemeProvider } from "@/components/theme-provider"
 const fontSans = FontSans({
   subsets: ["latin"],
   variable: "--font-sans",
+  display: 'swap',
 })
 
 interface RootLayoutProps {

--- a/apps/www/components/fonts.tsx
+++ b/apps/www/components/fonts.tsx
@@ -8,11 +8,13 @@ import {
 const fontSans = FontSans({
   subsets: ["latin"],
   variable: "--font-sans",
+  display: 'swap',
 })
 
 const fontMono = FontMono({
   subsets: ["latin"],
   variable: "--font-mono",
+  display: 'swap',
 })
 
 export function Fonts() {

--- a/templates/next-template/pages/_app.tsx
+++ b/templates/next-template/pages/_app.tsx
@@ -7,6 +7,7 @@ import "@/styles/globals.css"
 const fontSans = FontSans({
   subsets: ["latin"],
   variable: "--font-sans",
+  display: 'swap',
 })
 
 export default function App({ Component, pageProps }: AppProps) {


### PR DESCRIPTION
We should use `display: 'swap'` because Inter font does not load on hard reload and (sometimes) on the first visit to the site. Do a hard reload and reload to see the difference.

<img width="822" alt="Screen Shot 2023-01-26 at 09 53 23" src="https://user-images.githubusercontent.com/38227845/214774851-c2a1970b-7739-4015-8fd8-1e920baa7408.png">
<img width="802" alt="Screen Shot 2023-01-26 at 09 53 34" src="https://user-images.githubusercontent.com/38227845/214774858-1b944c95-81d7-4ea3-839b-84891e3db15a.png">

