### PR TITLE
avoid creating new tooltip provider for every tooltip

### DIFF
--- a/templates/next-template/components/ui/tooltip.tsx
+++ b/templates/next-template/components/ui/tooltip.tsx
@@ -5,11 +5,7 @@ import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 
 import { cn } from "@/lib/utils"
 
-const Tooltip = ({ ...props }) => (
-  <TooltipPrimitive.Provider>
-    <TooltipPrimitive.Root {...props} />
-  </TooltipPrimitive.Provider>
-)
+const Tooltip = TooltipPrimitive.Root
 Tooltip.displayName = TooltipPrimitive.Tooltip.displayName
 
 const TooltipTrigger = TooltipPrimitive.Trigger

--- a/templates/next-template/components/ui/tooltip.tsx
+++ b/templates/next-template/components/ui/tooltip.tsx
@@ -5,6 +5,7 @@ import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 
 import { cn } from "@/lib/utils"
 
+const TooltipProvider = TooltipPrimitive.Provider
 const Tooltip = TooltipPrimitive.Root
 Tooltip.displayName = TooltipPrimitive.Tooltip.displayName
 
@@ -26,4 +27,4 @@ const TooltipContent = React.forwardRef<
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 
-export { Tooltip, TooltipTrigger, TooltipContent }
+export { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent }


### PR DESCRIPTION
The user would instead put the provider in `_app.tsx` for example

This also allows user to pass props to the provider like in [radix-ui example](https://www.radix-ui.com/docs/primitives/components/tooltip#examples)
`<TooltipProvider delayDuration={500} skipDelayDuration={500}>`