### PR TITLE
fix: switch position issue

### DIFF
--- a/apps/www/components/ui/switch.tsx
+++ b/apps/www/components/ui/switch.tsx
@@ -11,7 +11,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-[24px] w-[44px] shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=unchecked]:bg-slate-200 data-[state=checked]:bg-slate-900 dark:focus:ring-slate-400 dark:focus:ring-offset-slate-900 dark:data-[state=unchecked]:bg-slate-700 dark:data-[state=checked]:bg-slate-400",
+      "peer inline-flex items-center h-[24px] w-[44px] shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=unchecked]:bg-slate-200 data-[state=checked]:bg-slate-900 dark:focus:ring-slate-400 dark:focus:ring-offset-slate-900 dark:data-[state=unchecked]:bg-slate-700 dark:data-[state=checked]:bg-slate-400",
       className
     )}
     {...props}


### PR DESCRIPTION
This is a bug fix for the issue https://github.com/shadcn/ui/issues/24

The switch position change on some screen sizes or in some zoom percent.
I solve that by putting the **items-center** on in this part of **switch.tsx** ui component.

```tsx
 <SwitchPrimitives.Root
    className={cn(
      "peer inline-flex items-center h-[24px] w-[44px] shrink-0 ....",
      className
    )}
    {...props}
    ref={ref}
  >
```