### PR TITLE
Fix: Issue 42: Use light text in TabsPrimitive.Trigger when dark mode

### DIFF
--- a/apps/www/components/ui/tabs.tsx
+++ b/apps/www/components/ui/tabs.tsx
@@ -28,7 +28,7 @@ const TabsTrigger = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.Trigger
     className={cn(
-      "inline-flex min-w-[100px] items-center justify-center rounded-[0.185rem] px-3 py-1.5  text-sm font-medium text-slate-700 transition-all  disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-white data-[state=active]:text-slate-900 data-[state=active]:shadow-sm dark:text-slate-200 dark:data-[state=active]:bg-slate-900",
+      "inline-flex min-w-[100px] items-center justify-center rounded-[0.185rem] px-3 py-1.5  text-sm font-medium text-slate-700 transition-all  disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-white data-[state=active]:text-slate-900 data-[state=active]:shadow-sm dark:text-slate-200 dark:data-[state=active]:bg-slate-900 dark:data-[state=active]:text-slate-100",
       className
     )}
     {...props}


### PR DESCRIPTION
Fixes https://github.com/shadcn/ui/issues/42 

## Before
![Screenshot 2023-01-30 at 19 04 54](https://user-images.githubusercontent.com/25059869/215560253-c8fea388-491f-41f2-b65e-6757613fff07.png)

## After
![Screenshot 2023-01-30 at 19 10 30](https://user-images.githubusercontent.com/25059869/215560292-0d0d3d7f-771f-4483-b792-8995d5963405.png)
