### PR TITLE
fix(slider): value prop not being passed

### DIFF
--- a/apps/www/components/ui/slider.tsx
+++ b/apps/www/components/ui/slider.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils"
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, value, ...props }, ref) => (
+>(({ className, ...props }, ref) => (
   <SliderPrimitive.Root
     ref={ref}
     className={cn(

--- a/templates/next-template/components/ui/slider.tsx
+++ b/templates/next-template/components/ui/slider.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils"
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, value, ...props }, ref) => (
+>(({ className, ...props }, ref) => (
   <SliderPrimitive.Root
     ref={ref}
     className={cn(


### PR DESCRIPTION
for some reason we were extracting the value prop from props but not passing it to the slider root.

fixed it by not extracting it from props, so its passed automatically.