### PR TITLE
chore: add husky prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ui",
   "version": "0.0.1",
   "private": true,
-  "license" : "MIT",
+  "license": "MIT",
   "author": {
     "name": "shadcn",
     "url": "https://twitter.com/shadcn"
@@ -18,7 +18,8 @@
     "lint": "turbo run lint",
     "preview": "turbo run preview",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
-    "sync:templates": "./scripts/sync-templates.sh \"templates/*\""
+    "sync:templates": "./scripts/sync-templates.sh \"templates/*\"",
+    "prepare": "husky install"
   },
   "packageManager": "pnpm@7.13.5",
   "dependencies": {


### PR DESCRIPTION
Husky is not installed automatically, I noticed this when I am trying to commit to my fork.

adding prepare script should work, see [reference](https://typicode.github.io/husky/#/?id=install)

also, you might want to re-run prettier. I think the pre-commit hook didn't run for some contributors

Here's the changes after I run it, let me know if you want me to push the prettier run commit 😃
![image](https://user-images.githubusercontent.com/55318172/216821302-d3d7a1c3-4d10-4878-8574-295d4197874e.png)
