### PR TITLE
fix(docs): fix destructive toast example src

### DIFF
--- a/apps/www/content/docs/primitives/toast.mdx
+++ b/apps/www/content/docs/primitives/toast.mdx
@@ -119,6 +119,6 @@ To display multiple toasts at the same time, you can update the `TOAST_LIMIT` in
 
 Use `toast({ variant: "destructive" }})` to display a destructive toast.
 
-<ComponentExample src="/components/examples/toast/with-action.tsx">
+<ComponentExample src="/components/examples/toast/destructive.tsx">
   <ToastDestructive />
 </ComponentExample>


### PR DESCRIPTION
The destructive toast component example used the wrong example src