### PR TITLE
Add prettier-plugin-tailwindcss

### DIFF
--- a/templates/next-template/package.json
+++ b/templates/next-template/package.json
@@ -63,7 +63,8 @@
     "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-tailwindcss": "^3.8.0",
     "postcss": "^8.4.14",
-    "prettier": "^2.7.1",
+    "prettier": "^2.8.4",
+    "prettier-plugin-tailwindcss": "^0.2.2",
     "tailwindcss": "^3.1.7",
     "typescript": "^4.5.3"
   }


### PR DESCRIPTION
Prettier plugin for Tailwind CSS that automatically sorts classes based on our recommended class order. [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss)