### PR TITLE
fix(www/command-menu): command menu keybinding not working

### DIFF
--- a/apps/www/components/command-menu.tsx
+++ b/apps/www/components/command-menu.tsx
@@ -27,7 +27,8 @@ export function CommandMenu({ ...props }: DialogProps) {
 
   React.useEffect(() => {
     const down = (e: KeyboardEvent) => {
-      if (e.key === "k" && e.metaKey) {
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
         setOpen((open) => !open)
       }
     }


### PR DESCRIPTION
prevent the default action of the browser in order to open the command menu.

https://user-images.githubusercontent.com/70624701/219858176-824cfc1b-c114-4d32-bd29-2d60fee5adbd.mp4

