### PR TITLE
feat(dialog): add exit animation

### DIFF
--- a/apps/www/components/ui/dialog.tsx
+++ b/apps/www/components/ui/dialog.tsx
@@ -16,9 +16,7 @@ const DialogPortal = ({
   ...props
 }: DialogPrimitive.DialogPortalProps) => (
   <DialogPrimitive.Portal className={cn(className)} {...props}>
-    <div className="fixed inset-0 z-50 flex items-start justify-center sm:items-center">
-      {children}
-    </div>
+    {children}
   </DialogPrimitive.Portal>
 )
 DialogPortal.displayName = DialogPrimitive.Portal.displayName
@@ -29,7 +27,7 @@ const DialogOverlay = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <DialogPrimitive.Overlay
     className={cn(
-      "data-[state=closed]:animate-out data-[state=open]:fade-in data-[state=closed]:fade-out fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-all duration-100",
+      "fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-all duration-100 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in",
       className
     )}
     {...props}
@@ -47,7 +45,8 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "animate-in data-[state=open]:fade-in-90 data-[state=open]:slide-in-from-bottom-10 sm:zoom-in-90 data-[state=open]:sm:slide-in-from-bottom-0 fixed z-50 grid w-full gap-4 rounded-b-lg bg-white p-6 sm:max-w-lg sm:rounded-lg",
+        "fixed top-0 left-1/2 z-50 grid w-full -translate-x-1/2 gap-4 rounded-b-lg bg-white p-6 sm:top-1/2 sm:max-w-lg sm:-translate-y-1/2 sm:rounded-lg",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in data-[state=closed]:slide-out-to-left-1/2 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-3/4 data-[state=closed]:slide-out-to-top-3/4 sm:max-w-lg data-[state=open]:sm:zoom-in-90 data-[state=closed]:sm:zoom-out-90 data-[state=closed]:sm:slide-out-to-top-1/2 data-[state=open]:sm:slide-in-from-top-1/2",
         "dark:bg-slate-900",
         className
       )}

--- a/apps/www/components/ui/dialog.tsx
+++ b/apps/www/components/ui/dialog.tsx
@@ -27,7 +27,7 @@ const DialogOverlay = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <DialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-all duration-100 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-all duration-100",
       className
     )}
     {...props}
@@ -46,7 +46,7 @@ const DialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         "fixed top-0 left-1/2 z-50 grid w-full -translate-x-1/2 gap-4 rounded-b-lg bg-white p-6 sm:top-1/2 sm:max-w-lg sm:-translate-y-1/2 sm:rounded-lg",
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in data-[state=closed]:slide-out-to-left-1/2 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-3/4 data-[state=closed]:slide-out-to-top-3/4 sm:max-w-lg data-[state=open]:sm:zoom-in-90 data-[state=closed]:sm:zoom-out-90 data-[state=closed]:sm:slide-out-to-top-1/2 data-[state=open]:sm:slide-in-from-top-1/2",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in data-[state=closed]:slide-out-to-left-1/2 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-3/4 data-[state=closed]:slide-out-to-top-3/4 data-[state=open]:sm:zoom-in-90 data-[state=closed]:sm:zoom-out-90 data-[state=closed]:sm:slide-out-to-top-1/2 data-[state=open]:sm:slide-in-from-top-1/2",
         "dark:bg-slate-900",
         className
       )}

--- a/examples/playground/components/ui/dialog.tsx
+++ b/examples/playground/components/ui/dialog.tsx
@@ -16,9 +16,7 @@ const DialogPortal = ({
   ...props
 }: DialogPrimitive.DialogPortalProps) => (
   <DialogPrimitive.Portal className={cn(className)} {...props}>
-    <div className="fixed inset-0 z-50 flex items-start justify-center sm:items-center">
-      {children}
-    </div>
+    {children}
   </DialogPrimitive.Portal>
 )
 DialogPortal.displayName = DialogPrimitive.Portal.displayName
@@ -29,7 +27,7 @@ const DialogOverlay = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <DialogPrimitive.Overlay
     className={cn(
-      "data-[state=closed]:animate-out data-[state=open]:fade-in data-[state=closed]:fade-out fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-all duration-100",
+      "fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-all duration-100 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in",
       className
     )}
     {...props}
@@ -47,7 +45,8 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "animate-in data-[state=open]:fade-in-90 data-[state=open]:slide-in-from-bottom-10 sm:zoom-in-90 data-[state=open]:sm:slide-in-from-bottom-0 fixed z-50 grid w-full gap-4 rounded-b-lg bg-white p-6 sm:max-w-lg sm:rounded-lg",
+        "fixed top-0 left-1/2 z-50 grid w-full -translate-x-1/2 gap-4 rounded-b-lg bg-white p-6 sm:top-1/2 sm:max-w-lg sm:-translate-y-1/2 sm:rounded-lg",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in data-[state=closed]:slide-out-to-left-1/2 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-3/4 data-[state=closed]:slide-out-to-top-3/4 sm:max-w-lg data-[state=open]:sm:zoom-in-90 data-[state=closed]:sm:zoom-out-90 data-[state=closed]:sm:slide-out-to-top-1/2 data-[state=open]:sm:slide-in-from-top-1/2",
         "dark:bg-slate-900",
         className
       )}

--- a/examples/playground/components/ui/dialog.tsx
+++ b/examples/playground/components/ui/dialog.tsx
@@ -27,7 +27,7 @@ const DialogOverlay = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <DialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-all duration-100 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-all duration-100",
       className
     )}
     {...props}
@@ -46,7 +46,7 @@ const DialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         "fixed top-0 left-1/2 z-50 grid w-full -translate-x-1/2 gap-4 rounded-b-lg bg-white p-6 sm:top-1/2 sm:max-w-lg sm:-translate-y-1/2 sm:rounded-lg",
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in data-[state=closed]:slide-out-to-left-1/2 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-3/4 data-[state=closed]:slide-out-to-top-3/4 sm:max-w-lg data-[state=open]:sm:zoom-in-90 data-[state=closed]:sm:zoom-out-90 data-[state=closed]:sm:slide-out-to-top-1/2 data-[state=open]:sm:slide-in-from-top-1/2",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in data-[state=closed]:slide-out-to-left-1/2 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-3/4 data-[state=closed]:slide-out-to-top-3/4 data-[state=open]:sm:zoom-in-90 data-[state=closed]:sm:zoom-out-90 data-[state=closed]:sm:slide-out-to-top-1/2 data-[state=open]:sm:slide-in-from-top-1/2",
         "dark:bg-slate-900",
         className
       )}


### PR DESCRIPTION
See shadcn/ui#72

Exit animations on Dialog didn't work because of the `<div>` between `Portal` and its children (`Overlay` and `Content`).

When removing those we need to position `Overlay` and `Content` differently, absolutely instead of centered within a flex box. Visually it should look the same with the addition of an exit animation (same as enter but in the opposite direction)