### PR TITLE
Fix description in `scroll-area.mdx`

### DIFF
--- a/apps/www/content/docs/primitives/scroll-area.mdx
+++ b/apps/www/content/docs/primitives/scroll-area.mdx
@@ -1,6 +1,6 @@
 ---
 title: Scroll-area
-description: Visually or semantically separates content.
+description: Augments native scroll functionality for custom, cross-browser styling.
 component: true
 radix:
   link: https://www.radix-ui.com/docs/primitives/components/scroll-area


### PR DESCRIPTION
Just noticed the description on https://ui.shadcn.com/docs/primitives/scroll-area was wrong, and duplicated from https://ui.shadcn.com/docs/primitives/separator.

This PR fixes that and updates the description to be the same as https://www.radix-ui.com/docs/primitives/components/scroll-area.

Thank you for these components 🙂 