### PR TITLE
Fix description in `dialog.mdx`

### DIFF
--- a/apps/www/content/docs/primitives/dialog.mdx
+++ b/apps/www/content/docs/primitives/dialog.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dialog
-description: A modal dialog that interrupts the user with important content and expects a response.
+description: A window overlaid on either the primary window or another dialog window, rendering the content underneath inert.
 featured: true
 component: true
 radix:


### PR DESCRIPTION
Just found what I'm guessing is another copy/paste mistake (see #136), this time on https://ui.shadcn.com/docs/primitives/dialog. It's the same as https://ui.shadcn.com/docs/primitives/alert-dialog.

This PR updates this description to the one found on https://www.radix-ui.com/docs/primitives/components/dialog.