### PR TITLE
docs: add missing imports

### DIFF
--- a/apps/www/content/docs/primitives/collapsible.mdx
+++ b/apps/www/content/docs/primitives/collapsible.mdx
@@ -33,7 +33,7 @@ This is the `<Collapsible />` primitive. You can place it in a file at `componen
 ## Usage
 
 ```tsx
-import { Collapsible } from "@/components/ui/collapsible"
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 ```
 
 ```tsx


### PR DESCRIPTION
This PR adds the missing imports for the Collapsible usage code.
![Screenshot_1](https://user-images.githubusercontent.com/81434423/228039943-7847d424-88c4-4785-85ea-473fe0de126f.png)
