### PR TITLE
Replacing third party @next/font with Next.js inbuilt next/font

### DIFF
--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Inter as FontSans } from "@next/font/google"
+import { Inter as FontSans } from "next/font/google"
 
 import "@/styles/globals.css"
 import { cn } from "@/lib/utils"

--- a/apps/www/components/fonts.tsx
+++ b/apps/www/components/fonts.tsx
@@ -3,7 +3,7 @@
 import {
   JetBrains_Mono as FontMono,
   Inter as FontSans,
-} from "@next/font/google"
+} from "next/font/google"
 
 const fontSans = FontSans({
   subsets: ["latin"],

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -14,7 +14,6 @@
     "format:check": "prettier --check \"**/*.{ts,tsx,mdx}\" --cache"
   },
   "dependencies": {
-    "@next/font": "^13.1.6",
     "@radix-ui/react-accessible-icon": "^1.0.1",
     "@radix-ui/react-accordion": "^1.1.0",
     "@radix-ui/react-alert-dialog": "^1.0.2",
@@ -50,7 +49,7 @@
     "cmdk": "^0.1.21",
     "contentlayer": "^0.3.0",
     "lucide-react": "0.105.0-alpha.4",
-    "next": "^13.1.6",
+    "next": "13.2.4",
     "next-contentlayer": "^0.3.0",
     "next-themes": "^0.2.1",
     "react": "^18.2.0",


### PR DESCRIPTION
This is not a necessary change as of now, but good to have, I just encountered it while using it, so thought of doing it
Issue #144 