### PR TITLE
fix: remove extra curly brace in style tag

### DIFF
--- a/templates/next-template/pages/_app.tsx
+++ b/templates/next-template/pages/_app.tsx
@@ -14,10 +14,10 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
       <style jsx global>{`
-				:root {
-					--font-sans: ${fontSans.style.fontFamily};
-				}
-			}`}</style>
+        :root {
+          --font-sans: ${fontSans.style.fontFamily};
+        }
+      `}</style>
       <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
         <Component {...pageProps} />
       </ThemeProvider>


### PR DESCRIPTION
An extra curly brace was hiding at the end of the style tag.