### PR TITLE
chore: unnecessary class

### DIFF
--- a/apps/www/components/ui/button.tsx
+++ b/apps/www/components/ui/button.tsx
@@ -11,7 +11,7 @@ const buttonVariants = cva(
         default:
           "bg-slate-900 text-white hover:bg-slate-700 dark:bg-slate-50 dark:text-slate-900",
         destructive:
-          "bg-red-500 text-white hover:bg-red-600 dark:hover:bg-red-600",
+          "bg-red-500 text-white hover:bg-red-600",
         outline:
           "bg-transparent border border-slate-200 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-100",
         subtle:


### PR DESCRIPTION
the hover:bg-red-600 already exists. There is no need to add dark:hover:bg-red-600