### PR TITLE
fix(menu triggers): prevents white trigger background when background is dark

### DIFF
--- a/apps/www/components/ui/context-menu.tsx
+++ b/apps/www/components/ui/context-menu.tsx
@@ -8,7 +8,19 @@ import { cn } from "@/lib/utils"
 
 const ContextMenu = ContextMenuPrimitive.Root
 
-const ContextMenuTrigger = ContextMenuPrimitive.Trigger
+const ContextMenuTrigger = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <ContextMenuPrimitive.Trigger
+    ref={ref}
+    className={cn("data-[state='open']:bg-inherit", className)}
+    {...props}
+  >
+    {children}
+  </ContextMenuPrimitive.Trigger>
+))
+ContextMenuTrigger.displayName = ContextMenuPrimitive.Trigger.displayName
 
 const ContextMenuGroup = ContextMenuPrimitive.Group
 

--- a/apps/www/components/ui/dropdown-menu.tsx
+++ b/apps/www/components/ui/dropdown-menu.tsx
@@ -8,7 +8,19 @@ import { cn } from "@/lib/utils"
 
 const DropdownMenu = DropdownMenuPrimitive.Root
 
-const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+const DropdownMenuTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.Trigger
+    ref={ref}
+    className={cn("data-[state='open']:bg-inherit", className)}
+    {...props}
+  >
+    {children}
+  </DropdownMenuPrimitive.Trigger>
+))
+DropdownMenuTrigger.displayName = DropdownMenuPrimitive.Trigger.displayName
 
 const DropdownMenuGroup = DropdownMenuPrimitive.Group
 


### PR DESCRIPTION
When creating a dark Footer component, use a DropdownMenu. If we open the dropdown (the Radix data-state goes to "open"), if the background is dark the button will behave with a white bg, and as the text was already white, it will be lost with the new trigger background.

The proposal is to leave a bg-inherit and take the bg of the main element.

![image](https://user-images.githubusercontent.com/22398603/230801488-14b5daf4-1113-4011-a975-167bc852d23d.png)

![image](https://user-images.githubusercontent.com/22398603/230801495-edf2eda4-ca09-49ec-acc2-c7d3ded2e724.png)

I have done this with both DropdownMenu and ContextMenu as the behavior is the same.