### PR TITLE
fix: remove styles for preventing scroll when modal is open

### DIFF
--- a/apps/www/styles/globals.css
+++ b/apps/www/styles/globals.css
@@ -92,13 +92,6 @@
   }
 }
 
-/** Prevent scrolling on body when modal is open */
-body[style*="pointer-events: none"] .overflow-auto,
-body[style*="pointer-events: none"] .overflow-y-auto,
-body[style*="pointer-events: none"] .overflow-x-auto {
-  overflow: hidden !important;
-}
-
 @media (max-width: 640px) {
   .container {
     @apply px-4;


### PR DESCRIPTION
First of all, I'd like to say thank you for a job well done.

I'm really impressed with this update as well.

With this update, when a modal was opened and `pointer-events: none` was added to the body style, elements with the class names `overflow-auto`, `overflow-y-auto`, and `overflow-x-auto` had the style `overflow: hidden !important` applied to them, preventing them from scrolling.

I think when using the Search documentation modal, it would scroll, but it doesn't, so I pull request.

![prevent-scrolling-modal](https://user-images.githubusercontent.com/61136724/233109324-1a1ff448-9208-48fe-9f9b-346cd263cc93.gif)

Thanks again!
