### PR TITLE
docs(www): Set correct colors for card in darkmode

### DIFF
--- a/apps/www/content/docs/theming.mdx
+++ b/apps/www/content/docs/theming.mdx
@@ -143,8 +143,8 @@ The following is the default color palette used by the components.
     --popover: 224 71% 4%;
     --popover-foreground: 215 20.2% 65.1%;
 
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 47.4% 11.2%;
+    --card: 224 71% 4%;
+    --card-foreground: 213 31% 91%;
 
     --border: 216 34% 17%;
     --input: 216 34% 17%;


### PR DESCRIPTION
Changed to be the same colors as the [template](https://github.com/shadcn/ui/blob/main/templates/next-template/styles/globals.css#L55).  With the current css the card background is always white