### PR TITLE
Fix horizontal scroll areas scrollbar thumb width

### DIFF
--- a/apps/www/components/ui/scroll-area.tsx
+++ b/apps/www/components/ui/scroll-area.tsx
@@ -35,7 +35,7 @@ const ScrollBar = React.forwardRef<
       orientation === "vertical" &&
         "h-full w-2.5 border-l border-l-transparent p-[1px]",
       orientation === "horizontal" &&
-        "h-2.5 border-t border-t-transparent p-[1px]",
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
       className
     )}
     {...props}


### PR DESCRIPTION
Without `flex-col` the scrollbar thumb would always be the full width of it's container.