### PR TITLE
Update default component installation path

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -212,7 +212,7 @@ async function promptForDestinationDir() {
       type: "text",
       name: "dir",
       message: "Where would you like to install the component(s)?",
-      initial: "./components/ui",
+      initial: "./src/components/ui",
     },
   ])
 


### PR DESCRIPTION
Updated default path to start with `./src` instead of `./components`