### PR TITLE
fix: uncontrolled input error on data-table

### DIFF
--- a/apps/www/app/examples/tasks/components/data-table-toolbar.tsx
+++ b/apps/www/app/examples/tasks/components/data-table-toolbar.tsx
@@ -26,7 +26,7 @@ export function DataTableToolbar<TData>({
       <div className="flex flex-1 items-center space-x-2">
         <Input
           placeholder="Filter tasks..."
-          value={table.getColumn("title")?.getFilterValue() as string}
+          value={(table.getColumn("title")?.getFilterValue() as string) ?? ""}
           onChange={(event) =>
             table.getColumn("title")?.setFilterValue(event.target.value)
           }

--- a/apps/www/components/examples/data-table/data-table.tsx
+++ b/apps/www/components/examples/data-table/data-table.tsx
@@ -73,7 +73,7 @@ export function DataTable<TData, TValue>({
       <div className="flex items-center py-4">
         <Input
           placeholder="Filter emails..."
-          value={table.getColumn("email")?.getFilterValue() as string}
+          value={(table.getColumn("email")?.getFilterValue() as string) ?? ""}
           onChange={(event) =>
             table.getColumn("email")?.setFilterValue(event.target.value)
           }

--- a/apps/www/content/docs/components/data-table.mdx
+++ b/apps/www/content/docs/components/data-table.mdx
@@ -595,7 +595,7 @@ export function DataTable<TData, TValue>({
       <div className="flex items-center py-4">
         <Input
           placeholder="Filter emails..."
-          value={table.getColumn("email")?.getFilterValue() as string}
+          value={(table.getColumn("email")?.getFilterValue() as string) ?? ""}
           onChange={(event) =>
             table.getColumn("email")?.setFilterValue(event.target.value)
           }


### PR DESCRIPTION
Add empty string as fallback if value is undefined or null to prevent error.
Fixes #336 