### PR TITLE
fix(code-block-wrapper): missing ']' in className

### DIFF
--- a/apps/www/components/code-block-wrapper.tsx
+++ b/apps/www/components/code-block-wrapper.tsx
@@ -31,7 +31,7 @@ export function CodeBlockWrapper({
         >
           <div
             className={cn(
-              "[&_pre]:max-h-[650px [&_pre]:my-0 [&_pre]:pb-[100px]",
+              "[&_pre]:max-h-[650px] [&_pre]:my-0 [&_pre]:pb-[100px]",
               !isOpened ? "[&_pre]:overflow-hidden" : "[&_pre]:overflow-auto]"
             )}
           >

--- a/apps/www/components/code-block-wrapper.tsx
+++ b/apps/www/components/code-block-wrapper.tsx
@@ -31,7 +31,7 @@ export function CodeBlockWrapper({
         >
           <div
             className={cn(
-              "[&_pre]:max-h-[650px] [&_pre]:my-0 [&_pre]:pb-[100px]",
+              "[&_pre]:my-0 [&_pre]:max-h-[650px] [&_pre]:pb-[100px]",
               !isOpened ? "[&_pre]:overflow-hidden" : "[&_pre]:overflow-auto]"
             )}
           >


### PR DESCRIPTION
Just a missing bracket in a tailwind custom value class

![image](https://github.com/shadcn/ui/assets/71119670/276cbc0e-7668-4898-9b02-e159924d1273)
