### PR TITLE
fix: showOutsideDays to false in calendar shifts the days to start of the row

### DIFF
--- a/apps/www/components/ui/calendar.tsx
+++ b/apps/www/components/ui/calendar.tsx
@@ -35,7 +35,7 @@ function Calendar({
         head_row: "flex",
         head_cell:
           "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
-        row: "flex w-full mt-2",
+        row: "flex first:justify-end w-full mt-2",
         cell: "text-center text-sm p-0 relative [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
         day: cn(
           buttonVariants({ variant: "ghost" }),


### PR DESCRIPTION
Pushing the days of the first row to end instead of start.

Fix for #361 

