### PR TITLE
Adding @radix-ui/react-slot Dependency to FormField Component in react-hook-form.mdx

### DIFF
--- a/apps/www/content/docs/forms/react-hook-form.mdx
+++ b/apps/www/content/docs/forms/react-hook-form.mdx
@@ -76,7 +76,7 @@ const form = useForm()
 1. Install the following dependencies:
 
 ```sh
-npm install react-hook-form zod @hookform/resolvers
+npm install react-hook-form zod @hookform/resolvers @radix-ui/react-slot
 ```
 
 2. Copy and paste the following `<Form />` component to your app.


### PR DESCRIPTION
# Adding @radix-ui/react-slot Dependency to FormField Component in the documentation

## Summary

This PR adds the "@radix-ui/react-slot" dependency to the FormField component. This addition is meant to streamline the DX and align it with the existing standards in the Button component.

## Changes

The following text has been changed, from:


```
npm install react-hook-form zod @hookform/resolvers
```

to:

```
npm install react-hook-form zod @hookform/resolvers @radix-ui/react-slot
```

## Additional Details

It's important to note that the "@radix-ui/react-slot" dependency is already being utilized in the Button component. However, the current [next-template](https://github.com/shadcn/next-template) still uses an older version without "@radix-ui/react-slot" implementation. 

Given that the installation guide for the Button component recommends installing "@radix-ui/react-slot", it seems fitting to include this in the FormField component as well. This not only brings consistency across components but also paves the way for updating the template to utilize "@radix-ui/react-slot". 

I look forward to your feedback and appreciate your consideration of this PR!