### PR TITLE
fix: Adding "aspect-square" class to RadioGroupItem Component

### DIFF
--- a/apps/www/components/ui/radio-group.tsx
+++ b/apps/www/components/ui/radio-group.tsx
@@ -28,7 +28,7 @@ const RadioGroupItem = React.forwardRef<
     <RadioGroupPrimitive.Item
       ref={ref}
       className={cn(
-        "h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}


### PR DESCRIPTION
# Adding "aspect-square" class to RadioGroupItem Component

## Summary

In this PR, I've added the TailwindCSS class "aspect-square" to the RadioGroupItem component in `apps/www/components/ui/radio-group.tsx`. This change enhances the visual consistency of radio buttons across different device sizes and widths.

## Changes

Here's a snippet of the code change:

**From:**

```tsx
className={cn(
  "h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
  className
)}
```

**To:**

```tsx
className={cn(
  "aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
  className
)}
```

## Rationale and Impact

Previously, the absence of the "aspect-square" class resulted in distorted shapes of radio button circles on smaller devices or at smaller widths. Here is a visual demonstration of the issue: 

![issue example](https://cdn.discordapp.com/attachments/777956112397107231/1109247574780682260/image.png).

By introducing the "aspect-square" class, the radio buttons maintain their circular shape regardless of device size or width, as demonstrated here: 

![solution example](https://media.discordapp.net/attachments/777956112397107231/1109248721302081659/image.png).

This change improves the user experience by maintaining a visually consistent interface across different device sizes and widths.

I welcome any feedback and appreciate your consideration of this PR!