### PR TITLE
Add Turbocache to speed up CI

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches: ["*"]
 
+env:
+  TURBO_API: "https://cache.turbocache.build"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "shadcn_ui"
+  TURBO_RUN_SUMMARY: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -12,6 +18,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - uses: turbocache-build/turbocache-action@v1
 
       - name: Install Node.js
         uses: actions/setup-node@v3
@@ -47,6 +55,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - uses: turbocache-build/turbocache-action@v1
 
       - name: Install Node.js
         uses: actions/setup-node@v3
@@ -84,6 +94,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - uses: turbocache-build/turbocache-action@v1
 
       - name: Install Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
Hey! We first would like to thank you for the awesome repo/components/template! We have used it on our own site [Turbocache](https://turbocache.build/).

As a token of our appreciation, we would like to give [Turbocache](https://turbocache.build/) to you for free. It is a remote caching server for Turborepo that also helps you analyze/visualize your Turborepo builds.

This PR adds the basic configuration to enable Turbocache for this repo. All you will need to do is add your `TURBO_TOKEN` to the repo secrets, which we can privately share with you.

If you are interested in faster builds, please let us know!