### PR TITLE
Automatic margin between button text and icon

### DIFF
--- a/apps/www/components/ui/button.tsx
+++ b/apps/www/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { VariantProps, cva } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background",
+  "inline-flex gap-3 items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background",
   {
     variants: {
       variant: {


### PR DESCRIPTION
I have implemented the gap-3 utility class to the button components. This addition allows for an automatic margin between the button text and the icon if one is added. This improvement ensures better visual alignment and spacing within the buttons