### PR TITLE
fix(card): wrong ts type declared in forwardRef

### DIFF
--- a/apps/www/components/ui/card.tsx
+++ b/apps/www/components/ui/card.tsx
@@ -30,7 +30,7 @@ const CardHeader = React.forwardRef<
 CardHeader.displayName = "CardHeader"
 
 const CardTitle = React.forwardRef<
-  HTMLParagraphElement,
+  HTMLHeadingElement,
   React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
   <h3


### PR DESCRIPTION
This PR fixes the type of the `CardTitle` from `HTMLParagraphElement` to `HTMLHeadingElement`.

Cheers 😇