### PR TITLE
fix: aspect ratio alt typo 

### DIFF
--- a/apps/www/content/docs/components/aspect-ratio.mdx
+++ b/apps/www/content/docs/components/aspect-ratio.mdx
@@ -56,7 +56,7 @@ import { AspectRatio } from "@/components/ui/aspect-ratio"
   <AspectRatio ratio={16 / 9}>
     <Image
       src="..."
-      alt=Image""
+      alt="Image"
       className="rounded-md object-cover"
     />
   </AspectRatio>


### PR DESCRIPTION
There is a small typo in the usage of the aspect ratio component docs
![image](https://github.com/shadcn/ui/assets/69092286/a2255673-96af-4124-b027-abf6b2bcf0bf)
