### PR TITLE
feat: deeper intellisense support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,11 @@
   "eslint.workingDirectories": [
     { "pattern": "apps/*/" },
     { "pattern": "packages/*/" }
+  ],
+  "tailwindCSS.classAttributes": [
+    "class",
+    "className",
+    "ngClass",
+    ".*Styles*"
   ]
 }

--- a/apps/www/content/docs/installation.mdx
+++ b/apps/www/content/docs/installation.mdx
@@ -11,7 +11,7 @@ description: How to install dependencies and structure your app.
     project. Follow the [Tailwind CSS installation instructions](https://tailwindcss.com/docs/installation) to get started.
 
   </AlertDescription>
-  
+
 </Alert>
 
 ## New Project
@@ -63,6 +63,13 @@ Add the following dependencies to your project:
 ```bash
 npm install tailwindcss-animate class-variance-authority clsx tailwind-merge lucide-react
 ```
+
+### Install Tailwind extension
+
+If you are using VS Code, install the Tailwind extension for linting and IntelliSense support:
+
+https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss
+
 
 ### Path Aliases
 

--- a/templates/next-template/.vscode/settings.json
+++ b/templates/next-template/.vscode/settings.json
@@ -1,4 +1,10 @@
 {
   "typescript.tsdk": "../../node_modules/.pnpm/typescript@4.9.5/node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "tailwindCSS.classAttributes": [
+    "class",
+    "className",
+    "ngClass",
+    ".*Styles*"
+  ]
 }

--- a/templates/next-template/components/ui/button.tsx
+++ b/templates/next-template/components/ui/button.tsx
@@ -1,15 +1,9 @@
 import * as React from "react"
 import { VariantProps, cva } from "class-variance-authority"
 
-import { cn, unmap } from "@/lib/utils"
+import { cn } from "@/lib/utils"
 
-const buttonBaseStyles = {
-  layout: "inline-flex items-center justify-center",
-  font: "text-sm font-medium transition-colors",
-  focus: "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-  disabled: "disabled:opacity-50 disabled:pointer-events-none",
-  other: "rounded-md ring-offset-background",
-}
+const buttonBaseStyles = "inline-flex items-center justify-center text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none rounded-md ring-offset-background";
 
 const buttonVariantStyles = {
   variant: {
@@ -30,7 +24,7 @@ const buttonVariantStyles = {
   },
 }
 
-const buttonVariants = cva(unmap(buttonBaseStyles),
+const buttonVariants = cva(buttonBaseStyles,
   {
     variants: buttonVariantStyles,
     defaultVariants: {

--- a/templates/next-template/components/ui/button.tsx
+++ b/templates/next-template/components/ui/button.tsx
@@ -1,29 +1,38 @@
 import * as React from "react"
 import { VariantProps, cva } from "class-variance-authority"
 
-import { cn } from "@/lib/utils"
+import { cn, unmap } from "@/lib/utils"
 
-const buttonVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background",
+const buttonBaseStyles = {
+  layout: "inline-flex items-center justify-center",
+  font: "text-sm font-medium transition-colors",
+  focus: "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+  disabled: "disabled:opacity-50 disabled:pointer-events-none",
+  other: "rounded-md ring-offset-background",
+}
+
+const buttonVariantStyles = {
+  variant: {
+    default: "bg-primary text-primary-foreground hover:bg-primary/90",
+    destructive:
+      "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+    outline:
+      "border border-input hover:bg-accent hover:text-accent-foreground",
+    secondary:
+      "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+    ghost: "hover:bg-accent hover:text-accent-foreground",
+    link: "underline-offset-4 hover:underline text-primary",
+  },
+  size: {
+    default: "h-10 py-2 px-4",
+    sm: "h-9 px-3 rounded-md",
+    lg: "h-11 px-8 rounded-md",
+  },
+}
+
+const buttonVariants = cva(unmap(buttonBaseStyles),
   {
-    variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline:
-          "border border-input hover:bg-accent hover:text-accent-foreground",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "underline-offset-4 hover:underline text-primary",
-      },
-      size: {
-        default: "h-10 py-2 px-4",
-        sm: "h-9 px-3 rounded-md",
-        lg: "h-11 px-8 rounded-md",
-      },
-    },
+    variants: buttonVariantStyles,
     defaultVariants: {
       variant: "default",
       size: "default",

--- a/templates/next-template/lib/utils.ts
+++ b/templates/next-template/lib/utils.ts
@@ -4,7 +4,3 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
-
-export function unmap(styles: Record<string, string>) {
-  return Object.values(styles).join(' ');
-}

--- a/templates/next-template/lib/utils.ts
+++ b/templates/next-template/lib/utils.ts
@@ -4,3 +4,7 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function unmap(styles: Record<string, string>) {
+  return Object.values(styles).join(' ');
+}


### PR DESCRIPTION
Background: I am new to Tailwind (and still pretty green with CSS generally). The IntelliSense and linting from the Tailwind VS Code extension has been my saving grace to understand what is going on.

However, out of the box the extension has pretty limited (or focused) areas where the IntelliSense will kick in.

This change expands the number of places where the Tailwind extension will provide IntelliSense support.

Any object with `Styles` (case sensitive) in the name will now trigger IntelliSense.  This is particularly useful in places like `Button`. Previously, no IntelliSense was provided to the `buttonVariant` styles.

**With this change (and some moving around), all `buttonVariant` styles have IntelliSense support.**

Example:
<img width="1114" alt="image" src="https://github.com/shadcn/ui/assets/1885864/e6fa436b-ef48-4383-818c-d8486ac82c83">

Note: The core change is to add `".*Styles*"` to the list of `tailwindCSS.classAttributes` which is where Tailwind knows to look in the file for IntelliSense. This was added to the root `settings.json` as well as the `settings.json` under the template.