### PR TITLE
fix(www): fix language placeholder on forms example

### DIFF
--- a/apps/www/app/examples/forms/account/account-form.tsx
+++ b/apps/www/app/examples/forms/account/account-form.tsx
@@ -179,8 +179,8 @@ export function AccountForm() {
                 </PopoverTrigger>
                 <PopoverContent className="w-[200px] p-0">
                   <Command>
-                    <CommandInput placeholder="Search framework..." />
-                    <CommandEmpty>No framework found.</CommandEmpty>
+                    <CommandInput placeholder="Search language..." />
+                    <CommandEmpty>No language found.</CommandEmpty>
                     <CommandGroup>
                       {languages.map((language) => (
                         <CommandItem


### PR DESCRIPTION
Fixed the language placeholder and the empty text when search and doesn't found a language.

Search placeholder:

<img width="883" alt="image" src="https://github.com/shadcn/ui/assets/2914170/8ae974a6-9d83-4022-b1c5-811ca9f1f548">

Empty text:

<img width="961" alt="image" src="https://github.com/shadcn/ui/assets/2914170/002dfdd0-4755-4c84-9428-8b9912e12b19">

