### PR TITLE
Choose the path that ends with "*" instead of paths[0] in tsconfig.json

### DIFF
--- a/packages/cli/src/utils/get-project-info.ts
+++ b/packages/cli/src/utils/get-project-info.ts
@@ -15,7 +15,7 @@ export async function getProjectInfo() {
   try {
     const tsconfig = await getTsConfig()
     const paths = tsconfig?.compilerOptions?.paths
-    const alias = paths ? Object.keys(paths)[0].replace("*", "") : null
+    const alias = paths ? Object.keys(paths).find(str => str.endsWith('*')).replace("*", "") : null
 
     return {
       tsconfig,


### PR DESCRIPTION
I was getting odd results like import { Button } from "contentlayer/generatedcomponents/ui/button" and I realized this was why:

In my tsconfig.json:
"paths": {
  "contentlayer/generated": ["./.contentlayer/generated"],
  "@/*": ["./*"]      
}

Not a high-priority change by any means, but just a minimal tweak to make this less likely by taking the path substitution that ends in a wildcard. Feel free to edit / improve / ignore as is fit, and thanks for this awesome project!