### PR TITLE
fix(progress): allow max value to be different from 100

### DIFF
--- a/apps/www/components/ui/progress.tsx
+++ b/apps/www/components/ui/progress.tsx
@@ -8,18 +8,20 @@ import { cn } from "@/lib/utils"
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
+>(({ className, value = 0, max = 100, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
       "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
       className
     )}
+    value={value}
+    max={max}
     {...props}
   >
     <ProgressPrimitive.Indicator
       className="h-full w-full flex-1 bg-primary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      style={{ transform: `translateX(-${max - value}%)` }}
     />
   </ProgressPrimitive.Root>
 ))


### PR DESCRIPTION
This PR allows the possibility of having a progress bar with a maximum value different from 100.

Also fixed an issue where we weren't passing the value prop to the root primitive, and this caused several aria attributes to be missing.