### PR TITLE
fix(accordion): flex styles breaking on with longer trigger text

### DIFF
--- a/apps/www/components/ui/accordion.tsx
+++ b/apps/www/components/ui/accordion.tsx
@@ -28,13 +28,13 @@ const AccordionTrigger = React.forwardRef<
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
+        "flex flex-1 items-center justify-between gap-4 py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
         className
       )}
       {...props}
     >
-      {children}
-      <ChevronDown className="h-4 w-4 transition-transform duration-200" />
+      <span className="flex-1 text-left">{children}</span>
+      <ChevronDown className="flex-0 h-4 w-4 transition-transform duration-200" />
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>
 ))


### PR DESCRIPTION
This PR should fix #593 and fix #316

Since there was no wrapping element for the inline text, flex was going crazy. The added span plus extra classes help with this issue. Now accordion items should look correct even when the trigger title is longer.

Before:
![image](https://github.com/shadcn/ui/assets/6538827/9b2b9500-c391-47a0-a6a1-88a7caef2ce1)


After:
![image](https://github.com/shadcn/ui/assets/6538827/b6cd3f07-796d-413a-93aa-870c884e42d6)
