### PR TITLE
fix(docs): Use "pnpm dlx" instead of "pnpx"

### DIFF
--- a/apps/www/lib/rehype-npm-command.ts
+++ b/apps/www/lib/rehype-npm-command.ts
@@ -44,7 +44,7 @@ export function rehypeNpmCommand() {
         const npmCommand = node.properties?.["__rawString__"]
         node.properties["__npmCommand__"] = npmCommand
         node.properties["__yarnCommand__"] = npmCommand
-        node.properties["__pnpmCommand__"] = npmCommand.replace("npx", "pnpx")
+        node.properties["__pnpmCommand__"] = npmCommand.replace("npx", "pnpm dlx")
       }
     })
   }


### PR DESCRIPTION
Switch to using `pnpm dlx` instead of `pnpx`, beacsue it is deprecated and (at least for me) did not ship by default when installing pnpm. 

See Stack Overflow post from Zoltan Kochan, maintainer of pnpm: https://stackoverflow.com/a/70266473