### PR TITLE
include `new-york` in schema.json

### DIFF
--- a/apps/www/public/schema.json
+++ b/apps/www/public/schema.json
@@ -4,7 +4,7 @@
   "properties": {
     "style": {
       "type": "string",
-      "enum": ["default"]
+      "enum": ["default", "new-york"]
     },
     "tailwind": {
       "type": "object",


### PR DESCRIPTION
Fixes the following issue:

<img width="523" alt="Screenshot 2023-06-22 at 10 06 25 PM" src="https://github.com/shadcn/ui/assets/1134738/c2f7d44a-8a56-4d97-8b61-315fd30734a2">
