### PR TITLE
Remove unused `PROJECT_DEPENDENCIES` variable

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,14 +9,6 @@ import { getPackageInfo } from "./utils/get-package-info"
 process.on("SIGINT", () => process.exit(0))
 process.on("SIGTERM", () => process.exit(0))
 
-const PROJECT_DEPENDENCIES = [
-  "tailwindcss-animate",
-  "class-variance-authority",
-  "clsx",
-  "tailwind-merge",
-  "lucide-react",
-]
-
 async function main() {
   const packageInfo = await getPackageInfo()
 


### PR DESCRIPTION
This PR enhances the code by removing the unused `PROJECT_DEPENDENCIES` variable from the `cli/src/index.ts` file. The variable is already defined and used in the `cli/src/commands/init.ts` file, so there is no need for redundant declarations.

```diff
- const PROJECT_DEPENDENCIES = [
-   "tailwindcss-animate",
-   "class-variance-authority",
-   "clsx",
-   "tailwind-merge",
- ]
```