### PR TITLE
Update skeleton.mdx - remove extra CLI instructions

### DIFF
--- a/apps/www/content/docs/components/skeleton.mdx
+++ b/apps/www/content/docs/components/skeleton.mdx
@@ -38,10 +38,6 @@ npx shadcn-ui@latest add skeleton
 
 </Tabs>
 
-```bash
-npx shadcn-ui@latest add skeleton
-```
-
 ## Usage
 
 ```tsx


### PR DESCRIPTION
# Remove extra cli instructions in Skeleton.

## Before:
<img width="783" alt="Screenshot 2023-06-23 at 11 57 48 PM" src="https://github.com/shadcn/ui/assets/48305203/89e5e0c4-ba06-4685-af9b-a29d9617e56c">
<img width="734" alt="Screenshot 2023-06-23 at 11 57 56 PM" src="https://github.com/shadcn/ui/assets/48305203/27670a69-5ee6-46c9-9fbb-aa4823589c0b">

## After:
<img width="731" alt="Screenshot 2023-06-23 at 11 58 44 PM" src="https://github.com/shadcn/ui/assets/48305203/f1fc9e5f-c9b5-47a2-8c84-702da420d40a">
<img width="714" alt="Screenshot 2023-06-23 at 11 58 54 PM" src="https://github.com/shadcn/ui/assets/48305203/2c37a3f0-daf2-4f1f-b26c-49e8bd6e0890">
