### PR TITLE
Update data-table-toolbar to correctly handle isFiltered

### DIFF
--- a/apps/www/app/examples/tasks/components/data-table-toolbar.tsx
+++ b/apps/www/app/examples/tasks/components/data-table-toolbar.tsx
@@ -17,7 +17,7 @@ interface DataTableToolbarProps<TData> {
 export function DataTableToolbar<TData>({
   table,
 }: DataTableToolbarProps<TData>) {
-  const isFiltered = table.getState().columnFilters.length > 0;
+  const isFiltered = table.getState().columnFilters.length > 0
 
   return (
     <div className="flex items-center justify-between">

--- a/apps/www/app/examples/tasks/components/data-table-toolbar.tsx
+++ b/apps/www/app/examples/tasks/components/data-table-toolbar.tsx
@@ -17,9 +17,7 @@ interface DataTableToolbarProps<TData> {
 export function DataTableToolbar<TData>({
   table,
 }: DataTableToolbarProps<TData>) {
-  const isFiltered =
-    table.getPreFilteredRowModel().rows.length >
-    table.getFilteredRowModel().rows.length
+  const isFiltered = table.getState().columnFilters.length > 0;
 
   return (
     <div className="flex items-center justify-between">


### PR DESCRIPTION
This just edits the example for data-table-toolbar. I have not checked if any docs need updating that reference this method of checking for isFiltered

If you select all filters that equals all rows we never display the reset button. 

We can get the state of selected columnFilters and if there is any selected display the reset button. 

