### PR TITLE
use ```pnpm dlx``` instead of ```pnpx```

### DIFF
--- a/apps/www/lib/rehype-npm-command.ts
+++ b/apps/www/lib/rehype-npm-command.ts
@@ -44,7 +44,7 @@ export function rehypeNpmCommand() {
         const npmCommand = node.properties?.["__rawString__"]
         node.properties["__npmCommand__"] = npmCommand
         node.properties["__yarnCommand__"] = npmCommand
-        node.properties["__pnpmCommand__"] = npmCommand.replace("npx", "pnpx")
+        node.properties["__pnpmCommand__"] = npmCommand.replace("npx", "pnpm dlx")
       }
     })
   }


### PR DESCRIPTION
use `pnpm dlx` for shadcn-ui as `pnpx` has been [deprecated as of pnpm v7](https://github.com/pnpm/pnpm/pull/3652)