### PR TITLE
feat: add destructive border to FormControl

### DIFF
--- a/apps/www/registry/default/ui/form.tsx
+++ b/apps/www/registry/default/ui/form.tsx
@@ -104,13 +104,14 @@ FormLabel.displayName = "FormLabel"
 const FormControl = React.forwardRef<
   React.ElementRef<typeof Slot>,
   React.ComponentPropsWithoutRef<typeof Slot>
->(({ ...props }, ref) => {
+>(({ className, ...props }, ref) => {
   const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
 
   return (
     <Slot
       ref={ref}
       id={formItemId}
+      className={cn(error && "border-destructive", className)}
       aria-describedby={
         !error
           ? `${formDescriptionId}`


### PR DESCRIPTION
This adds a `border-destructive` to the FormControl component in case of input error. I think this should be the default behavior in case of form error.
