### PR TITLE
docs: add vite installation guide

### DIFF
--- a/.changeset/thirty-points-fry.md
+++ b/.changeset/thirty-points-fry.md
@@ -1,0 +1,5 @@
+---
+"ui": patch
+---
+
+docs: add vite installation guide

--- a/apps/www/content/docs/installation.mdx
+++ b/apps/www/content/docs/installation.mdx
@@ -80,6 +80,85 @@ That's it. You can now start adding components to your project.
 npx shadcn-ui@latest add
 ```
 
+## Vite
+
+<Steps>
+
+### Create project
+
+Start by creating [a new Vite project](https://vitejs.dev/guide/#scaffolding-your-first-vite-project):
+
+```bash
+npx create vite@latest my-app --template react-ts --tailwind --eslint
+```
+
+### Install TailwindCSS
+
+> You can also follow the official Install Tailwind CSS with Vite guide [here](https://tailwindcss.com/docs/guides/vite).
+
+Install `tailwindcss` and its peer dependencies, then generate your `tailwind.config.js` and `postcss.config.js` files.
+
+```bash
+npm install -D tailwindcss postcss autoprefixer
+npx tailwindcss init -p
+```
+
+### Configure your template paths
+
+Add the paths to all of your template files in your `tailwind.config.js` file.
+
+```js {3-6} title="components.json"
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+```
+
+### Add the Tailwind directives to your CSS
+
+Add the `@tailwind` directives for each of Tailwind’s layers to your `./src/index.css` file.
+
+```css title="index.css"
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+### Run the CLI
+
+Run the `shadcn-ui` init command to setup your project:
+
+```bash
+npx shadcn-ui@latest init
+```
+
+### Configure components.json
+
+You will be asked a few questions to configure `components.json`:
+
+```txt showLineNumbers
+Which style would you like to use? › Default
+Which color would you like to use as base color? › Slate
+Where is your global CSS file? › › src/index.css
+Do you want to use CSS variables for colors? › no / yes
+Where is your tailwind.config.js located? › tailwind.config.cjs
+Configure the import alias for components: › @/components
+Configure the import alias for utils: › @/lib/utils
+Are you using React Server Components? › no / yes
+```
+
+</Steps>
+
+That's it. You can now start adding components to your project.
+
+```bash
+npx shadcn-ui@latest add
+```
+
 ## Other frameworks
 
-I'm looking for help writing guides for other frameworks. Help me write guides for Remix, Astro and Vite by [opening an PR](https://github.com/shadcn/ui).
+I'm looking for help writing guides for other frameworks. Help me write guides for Remix and Astro by [opening an PR](https://github.com/shadcn/ui).

--- a/apps/www/content/docs/installation.mdx
+++ b/apps/www/content/docs/installation.mdx
@@ -86,7 +86,7 @@ npx shadcn-ui@latest add
 
 ### Create project
 
-Start by creating [a new Vite project](https://vitejs.dev/guide/#scaffolding-your-first-vite-project):
+Start by creating [a new Vite project](https://vitejs.dev/guide/#scaffolding-your-first-vite-project) using [`create-vite`](https://github.com/vitejs/vite/tree/main/packages/create-vite) with the `react-ts` template:
 
 ```bash
 npx create vite@latest my-app --template react-ts --tailwind --eslint


### PR DESCRIPTION
## Description

Added [Vite](https://vitejs.dev/) installation guide for shadcn/ui.

## References

1. [Scaffolding Your First Vite Project](https://vitejs.dev/guide/#scaffolding-your-first-vite-project)
2. [Install Tailwind CSS with Vite](https://tailwindcss.com/docs/guides/vite)