### PR TITLE
fix(docs): remove unnecessary quotes

### DIFF
--- a/apps/www/content/docs/theming.mdx
+++ b/apps/www/content/docs/theming.mdx
@@ -170,7 +170,7 @@ module.exports = {
     extend: {
       colors: {
         warning: "hsl(var(--warning))",
-        "warning-foreground": "hsl(var(--warning-foreground))",
+        warning-foreground: "hsl(var(--warning-foreground))",
       },
     },
   },


### PR DESCRIPTION
I found unnecessary quotes, and delete them. 

before: 
![image](https://github.com/shadcn/ui/assets/101500659/6dff8e65-6757-4c79-9611-8c9a15a21931)
 
after: 
![image](https://github.com/shadcn/ui/assets/101500659/aef873de-a68e-4242-a2b4-55b81bcaa98f)
