### PR TITLE
docs(www): Add support for Tailwind's `alpha-value`

### DIFF
--- a/apps/www/content/docs/installation/manual.mdx
+++ b/apps/www/content/docs/installation/manual.mdx
@@ -73,38 +73,38 @@ module.exports = {
     },
     extend: {
       colors: {
-        border: "hsl(var(--border))",
-        input: "hsl(var(--input))",
-        ring: "hsl(var(--ring))",
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
+        border: "hsl(var(--border)/<alpha-value>)",
+        input: "hsl(var(--input)/<alpha-value>)",
+        ring: "hsl(var(--ring)/<alpha-value>)",
+        background: "hsl(var(--background)/<alpha-value>)",
+        foreground: "hsl(var(--foreground)/<alpha-value>)",
         primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))",
+          DEFAULT: "hsl(var(--primary)/<alpha-value>)",
+          foreground: "hsl(var(--primary-foreground)/<alpha-value>)",
         },
         secondary: {
-          DEFAULT: "hsl(var(--secondary))",
-          foreground: "hsl(var(--secondary-foreground))",
+          DEFAULT: "hsl(var(--secondary)/<alpha-value>)",
+          foreground: "hsl(var(--secondary-foreground)/<alpha-value>)",
         },
         destructive: {
-          DEFAULT: "hsl(var(--destructive))",
-          foreground: "hsl(var(--destructive-foreground))",
+          DEFAULT: "hsl(var(--destructive)/<alpha-value>)",
+          foreground: "hsl(var(--destructive-foreground)/<alpha-value>)",
         },
         muted: {
-          DEFAULT: "hsl(var(--muted))",
-          foreground: "hsl(var(--muted-foreground))",
+          DEFAULT: "hsl(var(--muted)/<alpha-value>)",
+          foreground: "hsl(var(--muted-foreground)/<alpha-value>)",
         },
         accent: {
-          DEFAULT: "hsl(var(--accent))",
-          foreground: "hsl(var(--accent-foreground))",
+          DEFAULT: "hsl(var(--accent)/<alpha-value>)",
+          foreground: "hsl(var(--accent-foreground)/<alpha-value>)",
         },
         popover: {
-          DEFAULT: "hsl(var(--popover))",
-          foreground: "hsl(var(--popover-foreground))",
+          DEFAULT: "hsl(var(--popover)/<alpha-value>)",
+          foreground: "hsl(var(--popover-foreground)/<alpha-value>)",
         },
         card: {
-          DEFAULT: "hsl(var(--card))",
-          foreground: "hsl(var(--card-foreground))",
+          DEFAULT: "hsl(var(--card)/<alpha-value>)",
+          foreground: "hsl(var(--card-foreground)/<alpha-value>)",
         },
       },
       borderRadius: {


### PR DESCRIPTION
Currently in the [Manual Installation Guide](https://ui.shadcn.com/docs/installation/manual), the provided `tailwind.config.js` contains colors that don't support Tailwind's `<alpha-value>`, which leads to unintended behavior (wrong style applied) to all elements that have color classNames that end with a `/opacityNumberHere`. For example, [the `Button` component uses opacity modifiers for hover-specific styling](https://github.com/shadcn/ui/blob/f78a4aaa28923a363bf17e6a5aad4b7b80a692bd/apps/www/registry/default/ui/button.tsx#L12). This styling simply **does not** work when using the Tailwind config provided in the Manual Installation guide.

For context, `<alpha-value>` is a opacity modifier that can be appended to the end of a Tailwind color, for example, using value `80` in `bg-primary/80` makes the opacity of the color of background of the element `80%` of it's actual value. The following is from the [Tailwind docs](https://tailwindcss.com/docs/customizing-colors#using-css-variables):

> define your colors in your configuration file, being sure to include the color space you’re using, and **the special `<alpha-value>` placeholder** that Tailwind will use to inject the alpha value when using an opacity modifier