### PR TITLE
Correct `htmlFor` attribute for the "Framework" label

### DIFF
--- a/apps/www/registry/default/example/card-with-form.tsx
+++ b/apps/www/registry/default/example/card-with-form.tsx
@@ -34,17 +34,17 @@ export default function CardWithForm() {
               <Input id="name" placeholder="Name of your project" />
             </div>
             <div className="flex flex-col space-y-1.5">
-              <Label htmlFor="name">Framework</Label>
+              <Label htmlFor="framework">Framework</Label>
               <Select>
-                <SelectTrigger>
+                <SelectTrigger id="framework">
                   <SelectValue placeholder="Select" />
-                  <SelectContent position="popper">
-                    <SelectItem value="next">Next.js</SelectItem>
-                    <SelectItem value="sveltekit">SvelteKit</SelectItem>
-                    <SelectItem value="astro">Astro</SelectItem>
-                    <SelectItem value="nuxt">Nuxt.js</SelectItem>
-                  </SelectContent>
                 </SelectTrigger>
+                <SelectContent position="popper">
+                  <SelectItem value="next">Next.js</SelectItem>
+                  <SelectItem value="sveltekit">SvelteKit</SelectItem>
+                  <SelectItem value="astro">Astro</SelectItem>
+                  <SelectItem value="nuxt">Nuxt.js</SelectItem>
+                </SelectContent>
               </Select>
             </div>
           </div>

--- a/apps/www/registry/new-york/example/card-with-form.tsx
+++ b/apps/www/registry/new-york/example/card-with-form.tsx
@@ -34,17 +34,17 @@ export default function CardWithForm() {
               <Input id="name" placeholder="Name of your project" />
             </div>
             <div className="flex flex-col space-y-1.5">
-              <Label htmlFor="name">Framework</Label>
+              <Label htmlFor="framework">Framework</Label>
               <Select>
-                <SelectTrigger>
+                <SelectTrigger id="framework">
                   <SelectValue placeholder="Select" />
-                  <SelectContent position="popper">
-                    <SelectItem value="next">Next.js</SelectItem>
-                    <SelectItem value="sveltekit">SvelteKit</SelectItem>
-                    <SelectItem value="astro">Astro</SelectItem>
-                    <SelectItem value="nuxt">Nuxt.js</SelectItem>
-                  </SelectContent>
                 </SelectTrigger>
+                <SelectContent position="popper">
+                  <SelectItem value="next">Next.js</SelectItem>
+                  <SelectItem value="sveltekit">SvelteKit</SelectItem>
+                  <SelectItem value="astro">Astro</SelectItem>
+                  <SelectItem value="nuxt">Nuxt.js</SelectItem>
+                </SelectContent>
               </Select>
             </div>
           </div>


### PR DESCRIPTION
Currently, the "Framework" label points to an incorrect field. This PR fixes that.