### PR TITLE
style(DashboardPage.svelte): adjust column span for Recent Sales card

### DIFF
--- a/apps/www/app/examples/dashboard/page.tsx
+++ b/apps/www/app/examples/dashboard/page.tsx
@@ -192,7 +192,7 @@ export default function DashboardPage() {
                     <Overview />
                   </CardContent>
                 </Card>
-                <Card className="col-span-3">
+                <Card className="col-span-4 lg:col-span-3">
                   <CardHeader>
                     <CardTitle>Recent Sales</CardTitle>
                     <CardDescription>


### PR DESCRIPTION
fix Recent Sales card span in md and smaller view

in the dashboard example page, the two cards are not aligned when viewport's width is smaller than 1024px