### PR TITLE
docs(www): improve astro guide

### DIFF
--- a/apps/www/content/docs/installation/astro.mdx
+++ b/apps/www/content/docs/installation/astro.mdx
@@ -111,7 +111,7 @@ import '@/styles/globals.css'
 
 ### Update astro tailwind config
 
-To prevent serving the Tailwind base styles twice, we need to tell Astro not to apply the base styles, since we already include them in our own `globals.css` file.
+To prevent serving the Tailwind base styles twice, we need to tell Astro not to apply the base styles, since we already include them in our own `globals.css` file. To do this, set the `applyBaseStyles` config option for the tailwind plugin in `astro.config.mjs` to `false`.
 
 ```ts {3,5} showLineNumbers
 export default defineConfig({

--- a/apps/www/content/docs/installation/astro.mdx
+++ b/apps/www/content/docs/installation/astro.mdx
@@ -113,15 +113,15 @@ import '@/styles/globals.css'
 
 To prevent serving the Tailwind base styles twice, we need to tell Astro not to apply the base styles, since we already include them in our own `globals.css` file. To do this, set the `applyBaseStyles` config option for the tailwind plugin in `astro.config.mjs` to `false`.
 
-```ts {3,5} showLineNumbers
+```ts {3-5} showLineNumbers
 export default defineConfig({
   integrations: [
     tailwind({
       applyBaseStyles: false,
     }),
   ],
-});
-``` 
+})
+```
 
 ### That's it
 

--- a/apps/www/content/docs/installation/astro.mdx
+++ b/apps/www/content/docs/installation/astro.mdx
@@ -109,6 +109,20 @@ import '@/styles/globals.css'
 ---
 ```
 
+### Update astro tailwind config
+
+To prevent serving the Tailwind base styles twice, we need to tell Astro not to apply the base styles, since we already include them in our own `globals.css` file.
+
+```ts {3,5} showLineNumbers
+export default defineConfig({
+  integrations: [
+    tailwind({
+      applyBaseStyles: false,
+    }),
+  ],
+});
+``` 
+
 ### That's it
 
 You can now start adding components to your project.


### PR DESCRIPTION
Hi, 

just started using the project in astro and went through the installation guide. By default, the `@astrojs/tailwind` integration includes the tailwind base styles (@tailwind base; @tailwind components; @tailwind utilities;) since we need a custom CSS file to adjust colors and stuff they are included twice in the build. 

We can tell astro to not `applyBaseStyles` because we do that on our own.
See docs for `@astrojs/tailwind`: https://docs.astro.build/en/guides/integrations-guide/tailwind/#applybasestyles

I updated the astro setup guide to add an additional step to set the options in `astro.config.mjs`