### PR TITLE
docs: add typescript configuration question to cli docs

### DIFF
--- a/apps/www/content/docs/cli.mdx
+++ b/apps/www/content/docs/cli.mdx
@@ -16,6 +16,7 @@ npx shadcn-ui@latest init
 You will be asked a few questions to configure `components.json`:
 
 ```txt showLineNumbers
+Would you like to use TypeScript (recommended)? no/yes
 Which style would you like to use? › Default
 Which color would you like to use as base color? › Slate
 Where is your global CSS file? › › app/globals.css


### PR DESCRIPTION
Typescript question was missing from the CLI docs (it is present on installation guides already).